### PR TITLE
updated README with new headCSS prop and mailchimp attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Use to format links. Requires an `href` prop. Always sets `target="_blank"` and 
 
 An image, without any pesky borders, outlines, or underlines by default. Requires a `src` prop, and `width` and `height` to be set. You can override the default styles (such as adding a border) using the `style` prop.
 
+## Head CSS and Media Queries
+You can pass a string prop `headCSS` to your `Email` component. You can see it in our [kitchenSink.js](https://github.com/chromakode/react-html-email/blob/master/examples/kitchenSink.js) example.
+
+## Mailchimp attributes
+If you're using Mailchimp and need to add their custom `mc:edit` attributes to your markup, we recommend using the [mailchimpify](http://github.com/Roilan/mailchimpify) module.
+
 ## License
 
 [MIT](https://github.com/chromakode/react-html-email/blob/master/LICENSE)


### PR DESCRIPTION
Updating the README with the new `headCSS` prop and adding a note about about the `mailchimpify` module.