### PR TITLE
add the filename in the warning message

### DIFF
--- a/src/StyleValidator.js
+++ b/src/StyleValidator.js
@@ -2,6 +2,13 @@ import supportMatrix from './supportMatrix.json'
 
 const capsRe = /[A-Z]/g
 
+const warningFilename = (file) => {
+  if (!file) return undefined
+
+  const split = file.split('/')
+  return split[split.length - 1]
+}
+
 export default class StyleValidator {
   constructor(config) {
     this.setConfig(config)
@@ -53,7 +60,7 @@ export default class StyleValidator {
       })
 
       for (const [msg, platforms] of messages) {
-        console.warn(`Warning: Style property \`${propName}\` supplied to \`${componentName}\`, in ${platforms.join(', ')}: ${msg.toLowerCase()}`)  // eslint-disable-line no-console
+        console.warn(`Warning in ${warningFilename(module.parent.parent.parent.filename)}: Style property \`${propName}\` supplied to \`${componentName}\`, in ${platforms.join(', ')}: ${msg.toLowerCase()}`)  // eslint-disable-line no-console
       }
 
       if (unsupported.length) {


### PR DESCRIPTION
As I'm building out a email template system with this module, I've noticed that warning message doesn't specify where it comes from. At the moment, we assume everything is one giant component, which we shouldn't.

I'm currently digging through `module.parent` but if you have a better way / idea of finding the root source, please share!