### PR TITLE
removed xmlns

### DIFF
--- a/src/injectReactEmailAttributes.js
+++ b/src/injectReactEmailAttributes.js
@@ -2,7 +2,6 @@ import { DOMProperty } from 'react/lib/ReactInjection'
 
 export const emailAttributes = {
   Properties: {
-    'xmlns': 0,
     'align': 0,
     'valign': 0,
     'bgcolor': 0,


### PR DESCRIPTION
Hey, we use your lib at mic.com to help make generating emails painless. Thanks for your work! 
Unfortunately the lib breaks with react 15.3.0 because of this PR https://github.com/facebook/react/pull/6471

This is a hotfix for it, not sure if you know of a better way to deal with this.

### Error
```
Invariant Violation: injectDOMPropertyConfig(...): You're trying to inject DOM property 'xmlns' which has already been injected. You may be accidentally injecting the same DOM property config twice, or you may be injecting two configs that have conflicting property names.
    at invariant (/Users/orrybaram/mic/cms/node_modules/fbjs/lib/invariant.js:38:15)
    at Object.DOMPropertyInjection.injectDOMPropertyConfig (/Users/orrybaram/mic/cms/node_modules/react/lib/DOMProperty.js:74:99)
    at injectReactEmailAttributes (/Users/orrybaram/mic/cms/node_modules/react-html-email/lib/injectReactEmailAttributes.js:29:31)
```