### PR TITLE
Use DOMProperty from react-dom instead of react

### DIFF
--- a/src/injectReactEmailAttributes.js
+++ b/src/injectReactEmailAttributes.js
@@ -1,6 +1,6 @@
 // ensure base DOM properties are already injected
 import 'react-dom'
-import DOMProperty from 'react/lib/DOMProperty'
+import DOMProperty from 'react-dom/lib/DOMProperty'
 
 export const emailAttributes = {
   Properties: {

--- a/test/injectReactEmailAttributes-test.js
+++ b/test/injectReactEmailAttributes-test.js
@@ -1,5 +1,5 @@
 import expect, { spyOn } from 'expect'
-import { DOMProperty } from 'react/lib/ReactInjection'
+import { DOMProperty } from 'react-dom/lib/ReactInjection'
 
 const modulePath = require.resolve('../src/injectReactEmailAttributes')
 


### PR DESCRIPTION
This fixes an issue with the latest version of React (clearly a breaking change that was not marked as such).